### PR TITLE
More control over logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ ExecStart=/path/to/wayland-proxy-virtwl --tag="[my-vm] " --wayland-display wayla
 WantedBy=default.target
 ```
 
+## Logging
+
+There are several ways to enable logging:
+
+- Running with `--verbose` will turn on all info-level logging.
+- Setting e.g. `WAYLAND_DEBUG_PROXY=client,server` will turn on info-level debugging for the listed components.
+- If `WAYLAND_DEBUG_PROXY` isn't set, `WAYLAND_DEBUG` is used instead. Setting this will also affect child processes.
+
+The available log sources are:
+
+- `client` -- log Wayland messages between the relay and the client applications.
+- `server` -- log Wayland messages between the relay and the host compositor.
+
+You can also suppress certain classes of log messages using e.g. `--log-suppress motion,shm,delete,region,drawing,hints`.
+The classes are:
+
+- `motion` -- pointer motion/frame events
+- `shm` -- managing shared memory pools
+- `delete` -- confirmation of object deletion
+- `region` -- setting up input regions
+- `drawing` -- attaching buffers, marking damage
+- `hints` -- window manager hints
+
+See [trace.ml](./trace.ml) for details.
+
 ## Using virtwl directly
 
 `tests/test.ml` is a simple test application that uses the virtwl kernel interface directly

--- a/log.ml
+++ b/log.ml
@@ -1,2 +1,2 @@
-let src = Logs.Src.create "virtwl-proxy" ~doc:"Wayland VM proxy"
+let src = Logs.Src.create "wl-proxy" ~doc:"Wayland proxy"
 include (val Logs.src_log src : Logs.LOG)

--- a/trace.ml
+++ b/trace.ml
@@ -1,27 +1,42 @@
 open Wayland
 
-let trace = function
-(*
-  | "xdg_toplevel"
-  | "xdg_surface"
-  | "wl_compositor"
-  | "wl_region"
-  | "wl_buffer"
-  | "wl_pointer"
-  | "wl_callback"
-  | "wl_keyboard"
-  | "wl_surface" -> false
-*)
+let motion = ref true
+let shm = ref true
+let delete = ref true
+let region = ref true
+let drawing = ref true
+let hints = ref true
+
+let trace iface name =
+  match iface, name with
+  | "wl_display", "delete_id" -> !delete
+  (* Motion *)
+  | "wl_pointer", ("frame" | "motion") -> !motion
+  (* Drawing *)
+  | "wl_surface", ("attach" | "frame" | "damage" | "damage_region") -> !drawing
+  (* Regions *)
+  | "wl_compositor", "create_region"
+  | "wl_region", _
+  | "wl_surface", "set_input_region" -> !region
+  (* Shared memory *)
+  | ("wl_shm" | "wl_shm_pool" | "wl_buffer"), _ -> !shm
+  (* Hints *)
+  | "xdg_toplevel", ("set_min_size" | "set_max_size")
+  | "xdg_surface", "set_window_geometry"
+  | "wl_surface", ("set_buffer_scale") -> !hints
   | _ -> true
 
-module Host : Client.TRACE = struct
+module Host = struct
+  let src = Logs.Src.create "wl-server" ~doc:"host-side of Wayland proxy"
+  module Log = (val Logs.src_log src : Logs.LOG)
+
   type role = [`Client]
 
   let inbound (type a) (proxy : (a, _, _) Proxy.t) msg =
-    Log.debug (fun f ->
+    Log.info (fun f ->
         let (module M : Metadata.S with type t = a) = Proxy.metadata proxy in
-        if trace M.interface then (
-          let msg_name, arg_info = M.events (Msg.op msg) in
+        let msg_name, arg_info = M.events (Msg.op msg) in
+        if trace M.interface msg_name then (
           f "@[<h>          <- %a.%s %a@]"
             Proxy.pp proxy
             msg_name
@@ -30,10 +45,10 @@ module Host : Client.TRACE = struct
       )
 
   let outbound (type a) (proxy : (a, _, _) Proxy.t) msg =
-    Log.debug (fun f ->
+    Log.info (fun f ->
         let (module M) = Proxy.metadata proxy in
-        if trace M.interface then (
-          let msg_name, arg_info = M.requests (Msg.op msg) in
+        let msg_name, arg_info = M.requests (Msg.op msg) in
+        if trace M.interface msg_name then (
           f "@[<h>          -> %a.%s %a@]"
             Proxy.pp proxy
             msg_name
@@ -42,15 +57,19 @@ module Host : Client.TRACE = struct
       )
 end
 
-module Client : Server.TRACE = struct
+module Client = struct
+  let src = Logs.Src.create "wl-client" ~doc:"client-side of Wayland proxy"
+  module Log = (val Logs.src_log src : Logs.LOG)
+
   type role = [`Server]
 
   let inbound (type a) (proxy : (a, _, _) Proxy.t) msg =
-    Log.debug (fun f ->
+    Log.info (fun f ->
         let (module M : Metadata.S with type t = a) = Proxy.metadata proxy in
-        if trace M.interface then (
-          let msg_name, arg_info = M.requests (Msg.op msg) in
-          f "-> @[<h>%a.%s %a@]"
+        let msg_name, arg_info = M.requests (Msg.op msg) in
+        if trace M.interface msg_name then (
+          f "%a -> @[<h>%a.%s %a@]"
+            Proxy.pp_transport proxy
             Proxy.pp proxy
             msg_name
             (Msg.pp_args arg_info) msg
@@ -58,14 +77,30 @@ module Client : Server.TRACE = struct
       )
 
   let outbound (type a) (proxy : (a, _, _) Proxy.t) msg =
-    Log.debug (fun f ->
+    Log.info (fun f ->
         let (module M) = Proxy.metadata proxy in
-        if trace M.interface then (
-          let msg_name, arg_info = M.events (Msg.op msg) in
-          f "<- @[<h>%a.%s %a@]"
+        let msg_name, arg_info = M.events (Msg.op msg) in
+        if trace M.interface msg_name then (
+          f "%a <- @[<h>%a.%s %a@]"
+            Proxy.pp_transport proxy
             Proxy.pp proxy
             msg_name
             (Msg.pp_args arg_info) msg
         )
       )
 end
+
+let reporter =
+  let report src level ~over k msgf =
+    let src = Logs.Src.name src in
+    msgf @@ fun ?header ?tags:_ fmt ->
+    Fmt.kstrf (fun line ->
+        print_endline line;
+        over ();
+        k ()
+      )
+      ("%11s %a: @[" ^^ fmt ^^ "@]")
+      src
+      Logs_fmt.pp_header (level, header)
+  in
+  { Logs.report = report }

--- a/virtwl/wayland_virtwl.ml
+++ b/virtwl/wayland_virtwl.ml
@@ -26,6 +26,8 @@ let of_context_fd fd : #Wayland.S.transport =
     (* The ioctl interface doesn't seem to have shutdown. *)
     method close =
       Lwt_unix.close fd
+
+  method pp f = Fmt.string f "virtwl"
   end
 
 let of_fd fd = fd


### PR DESCRIPTION
Use separate logs for client and server. Can be enabled using e.g. `WAYLAND_DEBUG_PROXY=client,server`. If `WAYLAND_DEBUG_PROXY` isn't set, it uses `WAYLAND_DEBUG` instead. However, setting this will also affect child processes.

Include the connection ID in log messages.

Also add `--log-suppress` to suppress certain classes of log messages.