### PR TITLE
Don't unscale cursor windows

### DIFF
--- a/relay.mli
+++ b/relay.mli
@@ -1,7 +1,7 @@
 type xwayland_hooks = <
   on_create_surface :
     'v. ([< `V1 | `V2 | `V3 | `V4 ] as 'v) H.Wl_surface.t -> 'v C.Wl_surface.t ->
-    set_configured:([`Show | `Hide] -> unit) ->
+    set_configured:([`Show | `Hide | `Unmanaged] -> unit) ->
     unit;
   (** Called when a new client wl_surface is created, along with the new host surface.
       Delivery of requests to the host surface is paused at this point; call [set_configured] to release the queue.

--- a/xwayland.ml
+++ b/xwayland.ml
@@ -29,7 +29,7 @@ type client_surface = [`V1 | `V2 | `V3 | `V4 ] Wayland.Wayland_server.Wl_surface
 type unpaired = {
   client_surface : client_surface;
   host_surface : host_surface;
-  set_configured : [`Show | `Hide] -> unit;
+  set_configured : [`Show | `Hide | `Unmanaged] -> unit;
 }
 
 type paired = {
@@ -1027,7 +1027,7 @@ let handle_xwayland ~config ~local_wayland ~local_wm_socket =
           if Hashtbl.mem t.unpaired client_surface_id then (
             Log.info (fun f -> f "%a doesn't correspond to an X11 window" Proxy.pp client_surface);
             Hashtbl.remove t.unpaired client_surface_id;
-            set_configured `Show
+            set_configured `Unmanaged
           );
           Lwt.return_unit
         )


### PR DESCRIPTION
Low-resolution cursors aren't a big problem and it's better to match the size of normal Wayland cursors. Also, Vim hides the pointer when you start typing by setting a 1x1 cursor. When unscaled, this is an illegal size and Sway hides the cursor, sending Xwayland a leave event. Xwayland then doesn't bother updating the cursor when Vim tries to show it again.