### PR TITLE
Manually unmap the virtio-gpu ring when done

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ If your interface needs to do things with virtio-gpu, it's probably easiest to g
 
 ## TODO
 
-- Find alternative to private `caml_unix_mapped_alloc`.
 - Only copy the buffer regions that have changed.
 
 [sommelier]: https://chromium.googlesource.com/chromiumos/platform2/+/main/vm_tools/sommelier/

--- a/virtio_gpu/dev.mli
+++ b/virtio_gpu/dev.mli
@@ -29,3 +29,6 @@ val handle_event : [`Wayland] t -> bytes -> [
 
 val close : _ t -> unit Lwt.t
 (** [close t] closes the underlying FD. *)
+
+val is_closed : _ t -> bool
+(** [is_closed t] is [true] after [close t] has been called. *)

--- a/virtio_gpu/utils.ml
+++ b/virtio_gpu/utils.ml
@@ -6,6 +6,8 @@ external ocaml_safe_map_file :
   ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
   = "ocaml_safe_map_file"
 
+external unmap : _ Bigarray.Genarray.t -> unit = "ocaml_ba_unmap"
+
 let safe_map_file ?(pos=0L) fd ~kind ~len = ocaml_safe_map_file fd kind pos len
 
 let pp_fd f (x : Unix.file_descr) = Fmt.int f (Obj.magic x : int)

--- a/virtio_gpu/utils.mli
+++ b/virtio_gpu/utils.mli
@@ -8,3 +8,8 @@ val safe_map_file :
     (which fails for special files such as shared buffers). *)
 
 val pp_fd : Unix.file_descr Fmt.t
+
+val unmap : _ Bigarray.Genarray.t -> unit
+(** [unmap ba] immediately unmaps an array previously mapped with {!safe_map_file},
+    without waiting for the garbage collector. You must not access [ba] after this
+    (it will probably give an error if you try, but the compiler may optimise this out). *)


### PR DESCRIPTION
The host doesn't treat the Wayland connection as closed until the ring is unmapped, which previously only happened when the garbage collector got to it. This resulted in windows not disappearing immediately when the application exited.

This is a hack: see https://github.com/ocaml/ocaml/pull/389

This also improves error handling around connection shutdown:

- Check the device is still open before accessing the shared ring (since it might now be unmapped).
- Silently ignore sends after a close. ocaml-wayland may need to flush its transmit buffer and this isn't an error.
- Return end-of-file immediately when reading if the device has been closed. `Cstruct.shift` checks that the buffer is still valid, which can give a poor error message if we close during a read.