### PR TITLE
Initial virtio-gpu support for dmabuf memory

### DIFF
--- a/virtio_gpu/dev.mli
+++ b/virtio_gpu/dev.mli
@@ -3,6 +3,20 @@
 type 'a t
   constraint 'a = [< `Wayland | `Alloc ]
 
+type query = {
+  width : int32;
+  height : int32;
+  drm_format : Drm_format.t;
+}
+
+type image = {
+  query : query;
+  fd : Unix.file_descr;
+  host_size : int64;
+  offset : int32;
+  stride : int32;
+}
+
 val of_fd : Lwt_unix.file_descr -> 'a t option
 (** [of_fd x] checks that [x] is a virtio-gpu device and
     initialises it. Returns [None] if it's not a virtio-device.
@@ -10,8 +24,8 @@ val of_fd : Lwt_unix.file_descr -> 'a t option
     for allocating host buffers, but not both (due to a race in the protocol).
     If you need to do both, open the device file twice and call this on both FDs. *)
 
-val alloc : [`Alloc] t -> size:int -> Unix.file_descr
-(** [alloc t ~size] allocates a buffer of [size] bytes on the host and returns a handle to it.
+val alloc : [`Alloc] t -> query -> image
+(** [alloc t query] allocates a buffer matching [query] on the host and returns a handle to it.
     Use {!Utils.safe_map_file} to map it. *)
 
 val poll : [`Wayland] t -> unit

--- a/virtio_gpu/drm_format.ml
+++ b/virtio_gpu/drm_format.ml
@@ -1,0 +1,21 @@
+type t = int32
+
+let of_str x =
+  assert (String.length x = 4);
+  let (+) = Int32.logor in
+  let char i shift = Int32.shift_left (Int32.of_int (Char.code x.[i])) shift in
+  (char 0 0) +
+  (char 1 8) +
+  (char 2 16) +
+  (char 3 24)
+
+let r8 = of_str "R8  "
+let bgr888 = of_str "BG24"
+let xr24 = of_str "XR24"
+let of_int32 x = x
+
+let pp f x =
+  let char i =
+    Char.chr (Int32.to_int (Int32.logand (Int32.shift_right x (i * 8)) 0xffl))
+  in
+  Fmt.pf f "%c%c%c%c (%lx)" (char 0) (char 1) (char 2) (char 3) x

--- a/virtio_gpu/drm_format.mli
+++ b/virtio_gpu/drm_format.mli
@@ -1,0 +1,11 @@
+type t = private int32
+
+val of_str : string -> t
+(** Parse a 4-character string as a format. *)
+
+val r8 : t
+val bgr888 : t
+val xr24 : t
+
+val of_int32 : int32 -> t
+val pp : t Fmt.t

--- a/virtio_gpu/dune
+++ b/virtio_gpu/dune
@@ -4,7 +4,7 @@
     (language c)
     (names virtio_gpu_stubs)
     (flags (:standard (:include c_flags.sexp))))
-  (libraries cstruct lwt.unix wayland)
+  (libraries cstruct lwt.unix wayland wayland.protocols)
   (c_library_flags (:include c_library_flags.sexp)))
 
 (rule

--- a/virtio_gpu/types.mli
+++ b/virtio_gpu/types.mli
@@ -28,6 +28,19 @@ module Res_handle : sig
   (** The value of the host's counter after increasing it. *)
 end
 
+module Capabilities : sig
+  type t = {
+    version : int32;
+    supported_channels : int32;
+    supports_dmabuf : bool;
+    supports_external_gpu_memory : bool;
+  }
+
+  val create_buffer : unit -> Cstruct.buffer
+
+  val of_buffer : Cstruct.buffer -> t
+end
+
 module Init_context : sig
   (** Tell Linux that we want to use the context feature, and set the parameters. *)
 
@@ -87,15 +100,6 @@ module Cross_domain_read_write : sig
   (** [create ~id buf ~len] is a message telling the host to write [buf[:len]] to host pipe [id]. *)
 end
 
-module Drm_format : sig
-  type t
-
-  val of_str : string -> t
-  (** Parse a 4-character string as a format. *)
-
-  val r8 : t
-end
-
 module Cross_domain_image_requirements : sig
   (** To share image data with the host, we tell it the details of the image and it
       returns some metadata and a resource ID which we can use to create the blob.
@@ -113,8 +117,8 @@ module Cross_domain_image_requirements : sig
 
   val parse :
     Cstruct.t ->
-    (strides:int32 ->
-     offsets:int32 ->
+    (stride0:int32 ->
+     offset0:int32 ->
      host_size:int64 ->
      blob_id:Res_handle.t -> 'a) ->
     'a

--- a/virtio_gpu/utils.ml
+++ b/virtio_gpu/utils.ml
@@ -3,11 +3,13 @@ external ocaml_safe_map_file :
   ('a, 'b) Bigarray.kind ->
   int64 ->
   int ->
+  int ->
   ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
   = "ocaml_safe_map_file"
 
 external unmap : _ Bigarray.Genarray.t -> unit = "ocaml_ba_unmap"
 
-let safe_map_file ?(pos=0L) fd ~kind ~len = ocaml_safe_map_file fd kind pos len
+let safe_map_file ?(pos=0L) fd ~kind ~len ~host_size =
+  ocaml_safe_map_file fd kind pos len host_size
 
 let pp_fd f (x : Unix.file_descr) = Fmt.int f (Obj.magic x : int)

--- a/virtio_gpu/utils.mli
+++ b/virtio_gpu/utils.mli
@@ -3,9 +3,12 @@ val safe_map_file :
   Unix.file_descr ->
   kind:('a, 'b) Bigarray.kind ->
   len:int ->
+  host_size:int ->
   ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
 (** [safe_map_file] is like {!Unix.map_file}, but it doesn't try to enlarge the file
-    (which fails for special files such as shared buffers). *)
+    (which fails for special files such as shared buffers).
+    @param host_size Size (in bytes) to pass to mmap call. May be larger than [len * kind_size].
+                     Sometimes mmap is fussy about short maps. *)
 
 val pp_fd : Unix.file_descr Fmt.t
 

--- a/virtio_gpu/virtio_gpu.mli
+++ b/virtio_gpu/virtio_gpu.mli
@@ -1,4 +1,6 @@
+module Drm_format = Drm_format
 module Dev = Dev
+module Wayland_dmabuf = Wayland_dmabuf
 
 type transport = < Wayland.S.transport; close : unit Lwt.t >
 
@@ -12,8 +14,13 @@ val connect_wayland : t -> transport Lwt.t
 
 val close : t -> unit Lwt.t
 
-val alloc : t -> size:int -> Unix.file_descr
-(** [alloc t ~size] allocates a buffer of [size] bytes on the host and returns a handle to it.
+val alloc : t -> Dev.query -> Dev.image
+(** [alloc t query] allocates a buffer matching [query] on the host and returns a handle to it.
     Use {!Utils.safe_map_file} to map it. *)
+
+val probe_drm : t -> Wayland_dmabuf.t -> bool Lwt.t
+(** [probe_drm t dma] tries to create a buffer backed by video memory.
+    Returns [true] if this works.
+    Caches the result on [t] for future calls. *)
 
 module Utils = Utils

--- a/virtio_gpu/wayland_dmabuf.ml
+++ b/virtio_gpu/wayland_dmabuf.ml
@@ -1,0 +1,91 @@
+open Wayland_protocols.Linux_dmabuf_unstable_v1_client
+open Lwt.Syntax
+
+type modifiers = { hi : int32; lo : int32 }
+type fmt = Drm_format.t * modifiers
+
+type t = {
+  proxy : [`V3] Zwp_linux_dmabuf_v1.t;
+  formats : (Drm_format.t, modifiers) Hashtbl.t;
+}
+
+let create wayland r =
+  let formats = Hashtbl.create 32 in
+  match Wayland.Registry.bind r @@ object
+      inherit [_] Zwp_linux_dmabuf_v1.v3
+      method on_format _ ~format:_ = ()
+      method on_modifier _ ~format ~modifier_hi:hi ~modifier_lo:lo =
+        let format = Drm_format.of_int32 format in
+        Logs.debug (fun f -> f "Format: %a hi:%lx lo:%lx"
+                       Drm_format.pp format
+                       hi lo);
+        Hashtbl.add formats format {hi; lo}
+    end
+  with
+  | proxy ->
+    let* () = Wayland.Client.sync wayland in
+    Lwt.return_some { proxy; formats }
+  | exception ex ->
+    Log.info (fun f -> f "Can't find dmabuf: %a" Fmt.exn ex);
+    Lwt.return_none
+
+let get_format t fmt =
+  match Hashtbl.find_opt t.formats fmt with
+  | None -> None
+  | Some mods -> Some (fmt, mods)
+
+let probe_drm t (image : Dev.image) =
+  let fmt = Drm_format.xr24 in
+  match Hashtbl.find_opt t.formats fmt with
+  | None ->
+    Log.info (fun f -> f "probe_drm: doesn't support test format %a, so can't probe" Drm_format.pp fmt);
+    Lwt.return false
+  | Some mods ->
+    let result, set_result = Lwt.wait () in
+    let params = Zwp_linux_dmabuf_v1.create_params t.proxy @@ object
+        inherit [_] Zwp_linux_buffer_params_v1.v1
+        method on_created self buffer =
+          Log.info (fun f -> f "probe_drm: succeeded - we can use video memory");
+          Wayland.Wayland_client.Wl_buffer.destroy (Wayland.Proxy.cast_version buffer);
+          Lwt.wakeup set_result true;
+          Zwp_linux_buffer_params_v1.destroy self
+        method on_failed self =
+          Log.info (fun f -> f "probe_drm: FAILED - we cannot use video memory");
+          Lwt.wakeup set_result false;
+          Zwp_linux_buffer_params_v1.destroy self
+      end in
+    Zwp_linux_buffer_params_v1.add params
+      ~fd:image.fd
+      ~offset:image.offset
+      ~stride:image.stride
+      ~modifier_lo:mods.lo
+      ~modifier_hi:mods.hi
+      ~plane_idx:0l;
+    Zwp_linux_buffer_params_v1.create params
+      ~width:1l
+      ~height:1l
+      ~format:(fmt :> int32)
+      ~flags:0l;
+    result
+
+let create_immed t (fmt, mods) (image : Dev.image) =
+  let params = Zwp_linux_dmabuf_v1.create_params t.proxy @@ object
+      inherit [_] Zwp_linux_buffer_params_v1.v1
+      method on_created _ _buffer = failwith "Shouldn't get called with create_immed!"
+      method on_failed _ = failwith "Shouldn't get called with create_immed!"
+    end in
+  Zwp_linux_buffer_params_v1.add params
+    ~fd:image.fd
+    ~offset:image.offset
+    ~stride:image.stride
+    ~modifier_lo:mods.lo
+    ~modifier_hi:mods.hi
+    ~plane_idx:0l;
+  fun buffer_handler ->
+    Zwp_linux_buffer_params_v1.create_immed params
+      ~width:image.query.width
+      ~height:image.query.height
+      ~format:(fmt : Drm_format.t :> int32)
+      ~flags:0l
+      (Wayland.Proxy.Handler.cast_version buffer_handler)
+    |> Wayland.Proxy.cast_version

--- a/virtio_gpu/wayland_dmabuf.mli
+++ b/virtio_gpu/wayland_dmabuf.mli
@@ -1,0 +1,24 @@
+(** Using Linux_dmabuf_unstable_v1 to create Wayland buffers backed by video memory. *)
+
+type modifiers = { hi : int32; lo : int32 }
+type fmt = Drm_format.t * modifiers
+
+type t
+
+val create : Wayland.Client.t -> Wayland.Registry.t -> t option Lwt.t
+(** [create wayland reg] gets a Linux_dmabuf_unstable_v1 from the registry and
+    collects the supported formats. Returns [None] if this interface is missing. *)
+
+val probe_drm : t -> Dev.image -> bool Lwt.t
+(** [probe_drm t img] tries to create a test Wl_buffer from [img].
+    Returns [true] iff this succeeds, indicating that we have access to video memory. *)
+
+val get_format : t -> Drm_format.t -> fmt option
+(** [get_format t fmt] returns the full format (with modifiers) for [fmt], if supported by [t]. *)
+
+val create_immed :
+  t ->
+  fmt -> Dev.image ->
+  ([`Wl_buffer], [`V1], [ `Client ]) #Wayland.Proxy.Handler.t ->
+  [`V1] Wayland.Wayland_client.Wl_buffer.t
+(** [create_immed t fmt img] returns a function for creating a Wl_buffer from [img]. *)


### PR DESCRIPTION
If crosvm is compiled with working minigbm support then allocations are in video memory and cannot be used with Wl_shm. However, if minigbm support is not compiled in (or doesn't support the host's hardware) then crosvm falls back to allocating host memory. Host memory can ONLY be used with Wl_shm. Therefore, try to detect which case it is and use the appropriate API. Currently only test.ml uses this, not the proxy itself.

I couldn't get this to work reliably. The scrolling pattern has lots of glitches, as if some pixels aren't making it to the video memory (needs a cache flush?). I tried adding some sync calls (`DMA_BUF_SYNC_END`, etc), but that didn't help, and crosvm keeps crashing with:

    [ERROR:src/linux.rs:2460] vcpu hit unknown error: Bad address (os error 14)

(line number might be a bit out as I added some debug prints)