### PR TITLE
Open dialog windows the same way as popups instead of as top-level window.

### DIFF
--- a/virtio_gpu/types.ml
+++ b/virtio_gpu/types.ml
@@ -80,7 +80,7 @@ module Init_context = struct
         init (Cstruct.shift cs 16) items
     in
     let n = List.length items in
-    let buffer = Bigarray_compat.(Array1.create char c_layout (n * 16)) in
+    let buffer = Bigarray.(Array1.create char c_layout (n * 16)) in
     let cs = Cstruct.of_bigarray buffer in
     init cs items;
     buffer

--- a/xwayland.ml
+++ b/xwayland.ml
@@ -545,7 +545,8 @@ let examine_window t window : window_info Lwt.t =
     let rec aux = function
       | [] -> `Unknown
       | ty :: _ when ty = type_normal -> `Normal
-      | ty :: _ when ty = type_dialog -> `Dialog
+      | ty :: _ when ty = type_dialog && not win_attrs.override_redirect -> `Dialog
+      | ty :: _ when ty = type_dialog && win_attrs.override_redirect -> `Popup
       | ty :: _ when ty = type_dropdown_menu -> `Popup
       | ty :: _ when ty = type_popup_menu -> `Popup
       | ty :: _ when ty = type_dnd -> `DnD


### PR DESCRIPTION
Java (at least) uses _NET_WM_WINDOW_TYPE_DIALOG for dropdown menus. Before this change, dropdown menus in Java applications would be opened in top-level windows and could be moved around independently, etc.. This change does not seem to have changed the behaviour of dialogs elsewhere (tested with firefox).