### PR TITLE
Relay xdg-decoration-unstable-v1

### DIFF
--- a/c.ml
+++ b/c.ml
@@ -6,3 +6,4 @@ include Wayland_protocols.Xdg_output_unstable_v1_server
 include Wayland_protocols.Gtk_primary_selection_server
 include Wayland_protocols.Wp_primary_selection_unstable_v1_server
 include Wayland_protocols.Server_decoration_server
+include Wayland_protocols.Xdg_decoration_unstable_v1_server

--- a/h.ml
+++ b/h.ml
@@ -6,3 +6,4 @@ include Wayland_protocols.Xdg_output_unstable_v1_client
 include Wayland_protocols.Gtk_primary_selection_client
 include Wayland_protocols.Wp_primary_selection_unstable_v1_client
 include Wayland_protocols.Server_decoration_client
+include Wayland_protocols.Xdg_decoration_unstable_v1_client

--- a/protocols.ml
+++ b/protocols.ml
@@ -6,3 +6,4 @@ include Wayland_protocols.Xdg_output_unstable_v1_proto
 include Wayland_protocols.Gtk_primary_selection_proto
 include Wayland_protocols.Wp_primary_selection_unstable_v1_proto
 include Wayland_protocols.Server_decoration_proto
+include Wayland_protocols.Xdg_decoration_unstable_v1_proto


### PR DESCRIPTION
This is the protocol used for XWayland SSD support, which was, weirdly enough, not actually relayed.