### PR TITLE
Update to dune 3.11

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.8)
+(lang dune 3.11)
 (name wayland-proxy-virtwl)
 (formatting disabled)
 (generate_opam_files true)
@@ -17,4 +17,4 @@
    (ocaml (>= 5.0.0))
    (fmt (>= 0.8.9))
    conf-pkg-config
-   (wayland (>= 1.1))))
+   (wayland (and (>= 1.1) (< 2.0)))))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -11,7 +11,7 @@ type t = {
   linux_dmabuf : (Virtio_gpu.Wayland_dmabuf.t * Virtio_gpu.Wayland_dmabuf.fmt) option;
   surface : [`V4] Wl_surface.t;
   gpu : Virtio_gpu.t;
-  mutable fg : int32;
+  fg : int32;
   mutable width : int;
   mutable height : int;
   mutable scroll : int;

--- a/virtio_gpu/dev.ml
+++ b/virtio_gpu/dev.ml
@@ -31,7 +31,7 @@ type 'a t = {
   ring : Cstruct.t;     (* Invalid if [is_closed] *)
   mutable pipe_of_id : pipe Res_handle.Map.t;
   mutable last_resource_id : Res_handle.t;
-  mutable alloc_cache : (query, image_template) Hashtbl.t;
+  alloc_cache : (query, image_template) Hashtbl.t;
 } constraint 'a = [< `Wayland | `Alloc ]
 
 let is_closed t =

--- a/wayland-proxy-virtwl.opam
+++ b/wayland-proxy-virtwl.opam
@@ -6,7 +6,7 @@ authors: ["talex5@gmail.com"]
 homepage: "https://github.com/talex5/wayland-proxy-virtwl"
 bug-reports: "https://github.com/talex5/wayland-proxy-virtwl/issues"
 depends: [
-  "dune" {>= "2.8"}
+  "dune" {>= "3.11"}
   "logs" {>= "0.7.0"}
   "cmdliner" {>= "1.1.0"}
   "cstruct" {>= "6.0.0"}
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "fmt" {>= "0.8.9"}
   "conf-pkg-config"
-  "wayland" {>= "1.1"}
+  "wayland" {>= "1.1" & < "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/xwayland.ml
+++ b/xwayland.ml
@@ -129,7 +129,7 @@ module Selection = struct
   type notify_key = {
     selection : X11.Atom.t;
     target : X11.Atom.t;
-  }
+  } [@@warning "-69"]
 
   type t = {
     x11 : X11.Display.t Lwt.t;


### PR DESCRIPTION
Fix some compiler warnings that are now enabled and add an upper bound on the version of ocaml-wayland.