### PR TITLE
Make X11 errors setting up new windows non-fatal

### DIFF
--- a/x11/error.ml
+++ b/x11/error.ml
@@ -34,6 +34,11 @@ type t = Cstruct.t
   } [@@little_endian]
 ]
 
+type error =
+  | X11_error of Cstruct.t
+
+type Eio.Exn.err += E of error
+
 let pp_code f x = Fmt.string f (code_to_string x)
 
 let pp f e =
@@ -43,4 +48,11 @@ let pp f e =
     (get_error_major_opcode e) (get_error_minor_opcode e)
     (get_error_seq e)
 
-let to_exn e = Failure (Fmt.str "%a" pp e)
+let () =
+  Eio.Exn.register_pp (fun f -> function
+      | E X11_error e -> pp f e; true
+      | _ -> false
+    )
+
+let to_exn e =
+  Eio.Exn.create (E (X11_error e))

--- a/x11/x11.mli
+++ b/x11/x11.mli
@@ -68,6 +68,11 @@ module Error : sig
   val pp_code : code Fmt.t
   val pp : t Fmt.t
   val to_exn : t -> exn
+
+  type error =
+    | X11_error of t
+
+  type Eio.Exn.err += E of error
 end
 
 module Geometry : sig


### PR DESCRIPTION
If a window is destroyed while we're examining it, just log the error and continue.