### PR TITLE
xwayland: remove buffer on unmap

### DIFF
--- a/x11/event.ml
+++ b/x11/event.ml
@@ -89,6 +89,8 @@ let read x =
 type handler = <
   map_request : window:window -> unit;
 
+  unmap_notify : window:window -> unit;
+
   configure_request :
     window:window -> width:int -> height:int -> unit;
 
@@ -116,6 +118,19 @@ module MapRequest = struct
       pad0 : uint8_t;
       seq : uint16_t;
       parent : uint32_t;
+      window : uint32_t;
+      unused : uint8_t [@len 20];
+    } [@@little_endian]
+  ]
+end
+
+module UnmapNotify = struct
+  [%%cstruct
+    type t = {
+      opcode : uint8_t;
+      pad0 : uint8_t;
+      seq : uint16_t;
+      event : uint32_t;
       window : uint32_t;
       unused : uint8_t [@len 20];
     } [@@little_endian]
@@ -212,6 +227,10 @@ let listen t (handler:handler) =
       Log.info (fun f -> f "Got MapRequest");
       let window = MapRequest.get_t_window body in
       handler#map_request ~window
+    | `Event (UnmapNotify, body) ->
+      Log.info (fun f -> f "Got UnmapNotify");
+      let window = UnmapNotify.get_t_window body in
+      handler#unmap_notify ~window
     | `Event (ConfigureRequest, body) ->
       Log.info (fun f -> f "Got ConfigureRequest");
       let window = Window.ConfigureRequest.get_t_window body in

--- a/x11/x11.mli
+++ b/x11/x11.mli
@@ -288,6 +288,8 @@ module Event : sig
   type handler = <
     map_request : window:Window.t -> unit;
 
+    unmap_notify : window:Window.t -> unit;
+
     configure_request :
       window:Window.t -> width:int -> height:int -> unit;
 


### PR DESCRIPTION
Xwayland sometimes delays destroying a window's buffer by about a second, even after the application has exited. This causes the window to remain on the screen for too long.

Reported by @puckipedia.

Fixes #63.