### PR TITLE
Update to new virtio-gpu cross-domain protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Note: the proxy previously used the virtwl protocol, but virtio-gpu has now repl
 ### crosvm setup
 
 You will need crosvm R104-14909 or later on the host.
-I use [gitlab:talex5/crosvm](https://gitlab.com/talex5/crosvm/),
+I use [gitlab:talex5/crosvm](https://gitlab.com/talex5/crosvm/-/tree/b0.1.2-rutabaga-release),
 which has some important fixes applied (see the Git log for details).
 It can be run as a Nix flake like this:
 
-    nix run 'git+https://gitlab.com/talex5/crosvm.git/?submodules=1'
+    nix run 'git+https://gitlab.com/talex5/crosvm.git?ref=b0.1.2-rutabaga-release&submodules=1'
 
 You will need to run with `--gpu=context-types=cross-domain:virgl2` to proxy Wayland connections.
 My [qubes-lite][] repository creates the scripts I use to run it, but these will need modifying for other systems.

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -140,7 +140,7 @@ let () =
   Switch.run @@ fun sw ->
   let dri_dir = Virtio_gpu.default_dri_dir env#fs in
   let gpu = Virtio_gpu.find_device ~sw dri_dir |> or_die in
-  let transport = Virtio_gpu.connect_wayland ~sw gpu in
+  let transport = Virtio_gpu.wayland_transport gpu in
   let display = Wayland.Client.connect ~sw transport in
   let r = Wayland.Registry.of_display display in
   let comp = Wayland.Registry.bind r @@ new Wl_compositor.v4 in

--- a/virtio_gpu/types.ml
+++ b/virtio_gpu/types.ml
@@ -18,8 +18,11 @@ module Res_handle = struct
 
   module Map = Map.Make(Int32)
 
-  let init = 1l
-  let next = Int32.add 2l
+  let pipe_read_start = 0x80000000l
+
+  let next_pipe_id x =
+    let x = Int32.succ x in
+    if x = 0l then pipe_read_start else x
 end
 
 module Capabilities = struct
@@ -147,10 +150,11 @@ end
 module Cross_domain_init = struct
   type t = [`Init] to_host
 
-  let create ~ring ~channel_type =
-    Cross_domain_header.create `INIT 8 @@ fun body ->
-    NE.set_uint32 body 0 ring;
-    NE.set_uint32 body 4 (match channel_type with
+  let create ~query_ring ~channel_ring ~channel_type =
+    Cross_domain_header.create `INIT 12 @@ fun body ->
+    NE.set_uint32 body 0 query_ring;
+    NE.set_uint32 body 4 channel_ring;
+    NE.set_uint32 body 8 (match channel_type with
         | `Wayland -> 0x0001l
         | `Camera  -> 0x0002l
       )

--- a/virtio_gpu/types.mli
+++ b/virtio_gpu/types.mli
@@ -15,17 +15,11 @@ module Res_handle : sig
 
   module Map : Map.S with type key = t
 
-  (** {2 Guessing}
+  val pipe_read_start : t
+  (** Read pipe IDs start at this value *)
 
-      The protocol requires us to guess what number the host will assign next.
-      Is it not possible to do this reliably (since it can update at any time),
-      but we do our best. *)
-
-  val init : t
-  (** The initial value of the host's resource counter. *)
-
-  val next : t -> t
-  (** The value of the host's counter after increasing it. *)
+  val next_pipe_id : t -> t
+  (** The next value of the pipe ID counter. *)
 end
 
 module Capabilities : sig
@@ -74,8 +68,12 @@ end
 module Cross_domain_init : sig
   type t = [`Init] to_host
 
-  val create : ring:Res_handle.t -> channel_type:[< `Camera | `Wayland ] -> t
-  (** [create ~ring ~channel_type] asks the host to use [ring] for the [channel_type] protocol. *)
+  val create :
+    query_ring:Res_handle.t ->
+    channel_ring:Res_handle.t ->
+    channel_type:[< `Camera | `Wayland ] -> t
+  (** [create ~query_ring ~channel_ring ~channel_type] asks the host
+      to use [query_ring] and [channel_ring] for the [channel_type] protocol. *)
 end
 
 module Cross_domain_poll : sig

--- a/virtio_gpu/virtio_gpu.mli
+++ b/virtio_gpu/virtio_gpu.mli
@@ -12,10 +12,9 @@ val default_dri_dir : 'a Eio.Path.t -> 'a Eio.Path.t
 val find_device : sw:Eio.Switch.t -> _ Eio.Path.t -> (t, [> `Msg of string]) result
 (** [find_device ~sw dri_dir] searches for a virtio-gpu device in [dri_dir] (see {!default_dri_dir}). *)
 
-val connect_wayland : sw:Eio.Switch.t -> t -> transport
-(** [connect_wayland t] creates a new Wayland transport from [t]. *)
-
 val close : t -> unit
+
+val wayland_transport : t -> transport
 
 val alloc : t -> Dev.query -> Dev.image
 (** [alloc t query] allocates a buffer matching [query] on the host and returns a handle to it.


### PR DESCRIPTION
crosvm updated the protocol to fix some races (see https://issuetracker.google.com/issues/259268477), and this requires some changes in the proxy too. In particular, copying text from the host to the guest had stopped working.

You will need to upgrade to a newer crosvm to use this version.