### PR TITLE
Implement socket activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Limitations:
 
 For more details, see [Isolating Xwayland in a VM][xwayland-blog].
 
+## Socket activation
+
+[systemd-style](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html)
+socket activation is supported. Sockets named "wayland" and/or "x11"
+may be provided, and the proxy will use them instead of creating its own.
+If a wayland socket is provided, the `--wayland-display` option cannot be used.
+For X11, the `--x-display` option is still needed, however.
+
 ## Logging
 
 There are several ways to enable logging:

--- a/dune-project
+++ b/dune-project
@@ -13,9 +13,9 @@
    (cmdliner (>= 1.1.0))
    (cstruct (>= 6.2.0))
    (eio (>= 0.12))
-   (eio_main (>= 0.12))
+   (eio_main (>= 1.1))
    (ppx_cstruct (>= 6.2.0))
-   (ocaml (>= 5.0.0))
+   (ocaml (>= 5.1.0))
    (fmt (>= 0.8.9))
    conf-pkg-config
    (wayland (>= 2.0))))

--- a/sd_listen_fds.ml
+++ b/sd_listen_fds.ml
@@ -1,0 +1,61 @@
+open Eio.Std
+
+module M = Map.Make(String)
+
+let (let*) = Result.bind
+
+let listen_fds_start = 3
+
+let init () =
+  match int_of_string (Sys.getenv "LISTEN_FDS") with
+  | exception Not_found -> Error "LISTEN_FDS not set"
+  | exception Invalid_argument _ -> Error "LISTEN_FDS not an integer"
+  | total_fds ->
+    let names =
+      match Sys.getenv_opt "LISTEN_FDNAMES" |> Option.value ~default:"" with
+      | "" -> []
+      | fdnames -> String.split_on_char ':' fdnames
+    in
+    if List.length names <> total_fds then Error "Wrong number of LISTEN_FDNAMES provided"
+    else (
+      let v = ref M.empty in
+      names |> List.iteri (fun i name ->
+          v := M.add_to_list name (i + listen_fds_start) !v
+        );
+      Ok v
+    )
+
+(* Maps not-yet-imported socket names to FDs (in reverse order). *)
+let available : (int list M.t ref, string) result =
+  match Sys.getenv_opt "LISTEN_PID" with
+  | Some p when p = string_of_int (Unix.getpid ()) -> init ()
+  | _ -> Ok (ref M.empty)       (* Socket activation is not being used, so no sockets *)
+
+let take name =
+  let* available in
+  match M.find_opt name !available with
+  | None -> Ok []
+  | Some fds ->
+    available := M.remove name !available;
+    Ok fds
+
+let listening_socket_from_fd ~sw fd =
+  let fd : Unix.file_descr = Obj.magic (fd : int) in
+  Unix.clear_nonblock fd;
+  Unix.set_close_on_exec fd;
+  (Eio_unix.Net.import_socket_listening ~sw ~close_unix:true fd :> Eio_unix.Net.listening_socket_ty r)
+
+let import ~sw name =
+  let* fds = take name in
+  match fds with
+  | [] -> Ok None
+  | [fd] -> Ok (Some (listening_socket_from_fd ~sw fd))
+  | _ -> Fmt.error "Multiple sockets named %S from service manager!" name
+
+let ensure_all_consumed () =
+  let* available in
+  match M.bindings !available with
+  | [] -> Ok ()
+  | fds ->
+    Fmt.error "Unexpected extra sockets %a from service manager"
+      Fmt.Dump.(list string) (List.map fst fds)

--- a/sd_listen_fds.mli
+++ b/sd_listen_fds.mli
@@ -1,0 +1,20 @@
+(** Systemd-style socket activation.
+
+    See {{:https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html}} *)
+
+open Eio.Std
+
+val import : sw:Switch.t -> string -> (Eio_unix.Net.listening_socket_ty r option, string) result
+(** [import ~sw name] takes the socket named [name] from the set of available sockets
+    received from the parent process.
+
+    Returns [Ok (Some listening_socket)] if a single socket with that name is available.
+
+    Returns [Ok None] if no socket with this name is available
+    (which could be because socket activation is not being used, or because it has already been imported).
+
+    Returns [Error msg] if there are multiple sockets with that name,
+    or if the environment variables are set up inconsistently. *)
+
+val ensure_all_consumed : unit -> (unit, string) result
+(** [ensure_all_consumed ()] checks that every socket passed to the process has been imported (with {!import}). *)

--- a/trace.ml
+++ b/trace.ml
@@ -142,7 +142,7 @@ module Ring_buffer = struct
 end
 
 let create_ring_control_socket ~sw ~fs ~wayland_display ring =
-  let ring_buffer_log_ctl = Printf.sprintf "/run/user/%d/%s-ctl" (Unix.getuid ()) wayland_display in
+  let ring_buffer_log_ctl = Printf.sprintf "/run/user/%d/%s-ctl" (Unix.getuid ()) (Filename.basename wayland_display) in
   if Sys.file_exists ring_buffer_log_ctl then Unix.unlink ring_buffer_log_ctl;
   Unix.mkfifo ring_buffer_log_ctl 0o600;
   let ring_buffer_log_ctl = (fs, ring_buffer_log_ctl) in

--- a/wayland-proxy-virtwl.opam
+++ b/wayland-proxy-virtwl.opam
@@ -11,9 +11,9 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "cstruct" {>= "6.2.0"}
   "eio" {>= "0.12"}
-  "eio_main" {>= "0.12"}
+  "eio_main" {>= "1.1"}
   "ppx_cstruct" {>= "6.2.0"}
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.1.0"}
   "fmt" {>= "0.8.9"}
   "conf-pkg-config"
   "wayland" {>= "2.0"}


### PR DESCRIPTION
Test with e.g.

    dune build && \
    systemd-socket-activate \
      -l /tmp/wayland-1 \
      -l /tmp/.X11-unix/X1 \
      --fdname wayland:x11 \
      ./_build/default/main.exe -v --virtio-gpu --tag '[socket] ' --x-display 1

This is similar to @alyssais's #80, but I put the activation protocol in its own module and made it more generic. This should make it easier to reuse in future, and makes main.ml a bit easier to read.