### PR TITLE
Cope with X IDs being reused quickly

### DIFF
--- a/src/xwayland.ml
+++ b/src/xwayland.ml
@@ -703,7 +703,9 @@ let pair t ~set_configured ~host_surface window =
         xdg_role = `None;
         override_redirect = info.win_attrs.override_redirect;
       } in
-      Hashtbl.add t.paired window paired;
+      (* Replace because this might be a new window with the same XID and we haven't yet
+         received the Wayland surface destroy message. *)
+      Hashtbl.replace t.paired window paired;
       Relay.set_surface_data host_surface (X11 paired);
       let fallback_parent = if parent = None then last_event_surface t else parent in
       match info.window_type, fallback_parent with
@@ -754,7 +756,8 @@ let unpair t paired =
   end;
   Xdg_surface.destroy paired.xdg_surface;
   H.Wp_viewport.destroy paired.viewport;
-  Hashtbl.remove t.paired paired.window;
+  (* Note: it might have been replaced by a newer window with the same XID first, so check: *)
+  if Hashtbl.find t.paired paired.window == paired then Hashtbl.remove t.paired paired.window;
   begin match t.pointer_surface with
     | Some p when p == paired ->
       t.pointer_surface <- None;


### PR DESCRIPTION
This could happen:

1. Wayland tells us new surface w1 was created.
2. X11 tells us new X window x1 matches w1.
3. X11 tells us x1 is destroyed; we do nothing.
4. Wayland tells us new surface w2 was created.
5. X11 tells us new X window x1 matches w2.
6. Wayland tells us w1 is destroyed.  
   We incorrectly remove the x1 -> w2 mapping, revealing the old x1 -> w1 mapping.

If x1 is now used as the parent for a new window, we find w1 instead of w2 and crash:

    xwayland [WARNING]: X11 WM failed: Exception: Invalid_argument("Attempt to use xdg_surface@54 after destroying it")

The fix is:

- Replace mappings instead of adding them.
- On destroy, only remove our mapping if it's still the current one.

This also fixes a problem with tooltips lingering longer than they should because we incorrectly ignore unmap requests as we try to unmap the old Wayland surface instead of the current one.